### PR TITLE
compute marathon.json's cpus by Mesos CPU/RAM ratio

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ before_install:
   - sudo docker build --tag=build-image .
 
 script:
-  - sudo docker run -v $(pwd):/build -v $HOME/.m2:/root/.m2 -v $HOME/.gradle:/root/.gradle -v /var/run/docker.sock:/var/run/docker.sock build-image test --info
+  - sudo docker network create --driver bridge my-network
+  - sudo docker run --network my-network -v $(pwd):/build -v $HOME/.m2:/root/.m2 -v $HOME/.gradle:/root/.gradle -v /var/run/docker.sock:/var/run/docker.sock build-image test --info
+  - sudo docker network rm my-network
 
 after_success:
   - test $TRAVIS_PULL_REQUEST == "false" && test "$TRAVIS_TAG" != "" && test $TRAVIS_REPO_SLUG == "alenkacz/gradle-marathon-deployer" && sudo docker run -v $(pwd):/build -v $HOME/.m2:/root/.m2 -v $HOME/.gradle:/root/.gradle -v /var/run/docker.sock:/var/run/docker.sock -e "BINTRAY_USER=$BINTRAY_USER" -e "BINTRAY_KEY=$BINTRAY_KEY" -e "GRADLE_PORTAL_KEY=$GRADLE_PORTAL_KEY" -e "GRADLE_PORTAL_SECRET=$GRADLE_PORTAL_SECRET" build-image bintrayUpload publishPlugins -Pversion="$TRAVIS_TAG" --info

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ Usage
 	}
 
 	apply plugin: 'marathon-deploy'
-    
+
     marathon {
-    	url = "http://path-to-your-marathon-instance.com"
+	url = "http://path-to-your-marathon-instance.com"
     }
 
 Properties
@@ -60,3 +60,7 @@ If you want to start using this feature, just add a jvmMem property on the top l
     }
 
 For this to work, when starting your JVM app, it must pass JAVA_OPTS environment variable to the JVM. JAVA_OPTS is handled automatically for you if you use [distribution plugin](https://docs.gradle.org/current/userguide/distribution_plugin.html).
+
+CPU profile
+-----------
+If you don't want to specify cpus option in marathon.json, you can get it computed for you. Simply omit cpus field in marathon.json. The cpus number gets calculated from required memory and Mesos resources ratio (number of CPUS / total RAM size). You can change cpus count policy by adding field cpuProfile with one of these values (low, normal, high). The default value is normal. Low option means that the computed value is multiplied by 0.3. High option means that the computed value is multiplied by 3.

--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -2,20 +2,64 @@ version: "2"
 
 services:
   zookeeper:
-    image: jplock/zookeeper:3.4.8
-  marathon:
-    image: mesosphere/marathon:v1.3.6
-    command:
-      --master local --zk zk://zookeeper:2181/marathon
+    image: garland/zookeeper
+    ports:
+     - "2181"
+
+  mesos-master:
+    image: mesosphere/mesos-master:1.0.0
+    entrypoint: [ "mesos-master" ]
+    ports:
+      - "5050:5050"
     links:
       - zookeeper
-    ports:
-      - "8080"
     environment:
       - MESOS_CLUSTER=local
-      - MESOS_HOSTNAME=mesos-master.docker
+      - MESOS_HOSTNAME=mesos-master
       - MESOS_LOG_DIR=/var/log
       - MESOS_QUORUM=1
       - MESOS_WORK_DIR=/var/lib/mesos
       - MESOS_ROLES=public
       - MESOS_ZK=zk://zookeeper:2181/mesos
+
+  mesos-slave:
+    image: mesosphere/mesos-slave:1.0.0
+    entrypoint:
+      - mesos-slave
+    privileged: true
+    ports:
+      - "5051"
+    links:
+      - zookeeper
+      - mesos-master
+    environment:
+      - MESOS_CONTAINERIZERS=mesos
+      - MESOS_ISOLATOR=cgroups/cpu, cgroups/mem
+      - MESOS_LOG_DIR=var/log
+      - MESOS_MASTER=zk://zookeeper:2181/mesos
+      - MESOS_PORT=5051
+      - MESOS_WORK_DIR=/var/lib/mesos
+      - MESOS_EXECUTOR_REGISTRATION_TIMEOUT=5mins
+      - MESOS_EXECUTOR_SHUTDOWN_GRACE_PERIOD=90secs
+      - MESOS_DOCKER_STOP_TIMEOUT=60secs
+      - MESOS_RESOURCES=cpus:4;mem:1280;disk:25600;ports(*):[12000-12999]
+
+  marathon:
+    image: mesosphere/marathon:latest
+    ports:
+      - "8080:8080"
+    links:
+      - zookeeper
+      - mesos-master
+      - mesos-slave
+    environment:
+      - MARATHON_ZK=zk://zookeeper:2181/marathon
+      - MARATHON_MASTER=zk://zookeeper:2181/mesos
+      - MARATHON_DECLINE_OFFER_DURATION=3600000
+      - MARATHON_MESOS_AUTHENTICATION_PRINCIPAL=marathon
+      - MARATHON_MESOS_ROLE=public
+
+networks:
+  default:
+    external:
+      name: my-network

--- a/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/CanaryDeployTask.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/CanaryDeployTask.groovy
@@ -2,7 +2,7 @@ package cz.alenkacz.gradle.marathon.deploy
 
 class CanaryDeployTask extends DeployTaskBase {
     public CanaryDeployTask() {
-        super({ PluginExtension marathonJsonPath -> new CanaryMarathonJsonEnvelope(marathonJsonPath) })
+        super({ PluginExtension marathonJsonPath, BigDecimal mesosResourcesRatio -> new CanaryMarathonJsonEnvelope(marathonJsonPath, mesosResourcesRatio) })
 
         group = 'publishing'
         description = 'Deploys canary of your application to Marathon'

--- a/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/CanaryMarathonJsonEnvelope.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/CanaryMarathonJsonEnvelope.groovy
@@ -1,8 +1,8 @@
 package cz.alenkacz.gradle.marathon.deploy
 
 class CanaryMarathonJsonEnvelope extends MarathonJsonEnvelope {
-    CanaryMarathonJsonEnvelope(PluginExtension pluginExtension) {
-        super(pluginExtension)
+    CanaryMarathonJsonEnvelope(PluginExtension pluginExtension, BigDecimal mesosResourcesRatio) {
+        super(pluginExtension, mesosResourcesRatio)
 
         parsedJson.id = getApplicationId() + "-canary"
         parsedJson.instances = 1

--- a/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/DeployTask.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/DeployTask.groovy
@@ -2,7 +2,7 @@ package cz.alenkacz.gradle.marathon.deploy
 
 class DeployTask extends DeployTaskBase {
     public DeployTask() {
-        super({ PluginExtension pluginExtension -> new MarathonJsonEnvelope(pluginExtension) })
+        super({ PluginExtension pluginExtension, BigDecimal mesosResourceRatio -> new MarathonJsonEnvelope(pluginExtension, mesosResourceRatio) })
 
         group = 'publishing'
         description = 'Deploys your application to Marathon'

--- a/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/DeployTaskBase.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/DeployTaskBase.groovy
@@ -33,9 +33,9 @@ class DeployTaskBase extends DefaultTask  {
         if (!pluginExtension.url) {
             throw new Exception("Missing required property marathon url")
         }
+        def marathonApiUrl = pluginExtension.getMarathonApiUrl()
 
-        def marathonApiUrl = "${pluginExtension.url}/v2"
-        def marathonJsonEnvelope = marathonJsonFactory(pluginExtension)
+        def marathonJsonEnvelope = marathonJsonFactory(pluginExtension, new ResourcesRatioFetcher(marathonApiUrl).getMesosResourcesRatio())
         def String applicationId = marathonJsonEnvelope.getApplicationId()
         def String marathonJson = marathonJsonEnvelope.getFinalJson(logger)
         def String deploymentId
@@ -61,6 +61,7 @@ class DeployTaskBase extends DefaultTask  {
             println("Deployment was successful")
         }
     }
+
 
     private String prepareMarathonDeployUrl(String marathonApiUrl, String applicationId) {
         "${marathonApiUrl}/apps/${URLEncoder.encode(applicationId, StandardCharsets.UTF_8.toString())}${pluginExtension.forceDeployment ? "?force=true" : ""}"

--- a/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/PluginExtension.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/PluginExtension.groovy
@@ -4,6 +4,7 @@ import groovy.time.TimeDuration
 
 class PluginExtension {
     def String url
+    def String marathonApiUrl
     def String dockerImageName
     def String pathToJsonFile
     def TimeDuration verificationTimeout
@@ -20,5 +21,9 @@ class PluginExtension {
         verificationTimeout = new TimeDuration(0, 0, 90, 0)
         deploymentRequestTimeout = new TimeDuration(0, 0, 5, 0)
         jvmOverhead = 200
+    }
+
+    public String getMarathonApiUrl() {
+        return "${this.url}/v2"
     }
 }

--- a/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/PrintTask.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/PrintTask.groovy
@@ -8,7 +8,7 @@ class PrintTask extends DefaultTask {
 
     @TaskAction
     def print() {
-        def marathonJsonEnvelope = new MarathonJsonEnvelope(pluginExtension)
+        def marathonJsonEnvelope = new MarathonJsonEnvelope(pluginExtension, new ResourcesRatioFetcher(pluginExtension.getMarathonApiUrl()).getMesosResourcesRatio())
         println(marathonJsonEnvelope.getFinalJson(new NoOpLogger()))
     }
 }

--- a/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/ResourcesRatioFetcher.groovy
+++ b/src/main/groovy/cz/alenkacz/gradle/marathon/deploy/ResourcesRatioFetcher.groovy
@@ -1,0 +1,53 @@
+package cz.alenkacz.gradle.marathon.deploy
+
+//import org.asynchttpclient.AsyncHttpClient
+import org.asynchttpclient.DefaultAsyncHttpClient
+import groovy.json.JsonSlurper
+
+class ResourcesRatioFetcher {
+
+    def marathonApiUrl
+    def AsyncHttpClient
+    def jsonSlurper
+
+    ResourcesRatioFetcher(String marathonApiUrl) {
+        this.marathonApiUrl = marathonApiUrl
+        this.asyncHttpClient = new DefaultAsyncHttpClient()
+        this.jsonSlurper = new groovy.json.JsonSlurper()
+    }
+
+    public BigDecimal getMesosResourcesRatio() {
+
+        println("Marathon API URL: ${this.marathonApiUrl}")
+
+        String mesosUrl
+        try {
+            def marathon_result = asyncHttpClient.prepareGet("${this.marathonApiUrl}/info").execute().get()
+            if (marathon_result.statusCode != 200) {
+                throw new MarathonDeployerException("Marathon responded with code ${marathon_result.statusCode} when fetching info. Response: ${marathon_result.getResponseBody(StandardCharsets.UTF_8)}")
+            }
+            mesosUrl = jsonSlurper.parse(marathon_result.getResponseBodyAsBytes()).marathon_config.mesos_leader_ui_url
+        } catch (Exception e) {
+            throw new MarathonDeployerException("Error when requesting info from Marathon", e)
+        }
+
+        BigDecimal ratio
+        try {
+            def mesos_result = asyncHttpClient.prepareGet("${mesosUrl}state.json").execute().get()
+            if (mesos_result.statusCode != 200) {
+                throw new MarathonDeployerException("Mesos responded with code ${mesos_result.statusCode} when state.json. Response: ${mesos_result.getResponseBody(StandardCharsets.UTF_8)}")
+            }
+            def slaves = jsonSlurper.parse(mesos_result.getResponseBodyAsBytes()).slaves
+            def cpus = slaves.collect { it.resources.cpus }.sum()
+            def mem  = slaves.collect { it.resources.mem  }.sum()
+            ratio = cpus / mem
+        } catch (Exception e) {
+            throw new MarathonDeployerException("Error when requesting state info from Mesos", e)
+        }
+
+
+        return ratio
+    }
+
+}
+

--- a/src/test/groovy/cz/alenkacz/gradle/marathon/deploy/DeployTaskTest.groovy
+++ b/src/test/groovy/cz/alenkacz/gradle/marathon/deploy/DeployTaskTest.groovy
@@ -35,7 +35,7 @@ class DeployTaskTest extends Specification {
             def extension = (PluginExtension) project.extensions.findByName('marathon')
             extension.setPathToJsonFile("non/existing/path.json")
             extension.setDockerImageName("imagename")
-            extension.setUrl("http://marathon.url")
+            extension.setUrl(MarathonMother.getMarathonUrl())
         when:
             project.tasks.deployToMarathon.deployToMarathon()
 

--- a/src/test/groovy/cz/alenkacz/gradle/marathon/deploy/MarathonJsonEnvelopeTest.groovy
+++ b/src/test/groovy/cz/alenkacz/gradle/marathon/deploy/MarathonJsonEnvelopeTest.groovy
@@ -64,4 +64,19 @@ class MarathonJsonEnvelopeTest extends Specification {
         then:
         actual.env.JAVA_OPTS == "-Xmx128m -Dabc=1"
     }
+
+    def "add cpus field based on cloud's cpu/memory ratio"() {
+        given:
+        def marathonWithoutCpus = MarathonJsonMother.validMarathonJsonWithoutCpusPath()
+        def extension = new PluginExtension()
+        extension.setPathToJsonFile(marathonWithoutCpus)
+        def ratio = 0.1
+
+        when:
+        def target = new MarathonJsonEnvelope(extension, ratio)
+        def actual = new JsonSlurper().parse(target.getFinalJson(new NoOpLogger()).toCharArray())
+
+        then:
+        actual.cpus == 1
+    }
 }

--- a/src/test/groovy/cz/alenkacz/gradle/marathon/deploy/MarathonJsonMother.groovy
+++ b/src/test/groovy/cz/alenkacz/gradle/marathon/deploy/MarathonJsonMother.groovy
@@ -98,4 +98,20 @@ class MarathonJsonMother {
         }
         return marathonFilePath
     }
+
+    static def String validMarathonJsonWithoutCpusPath() {
+        def marathonFilePath = ""
+        File.createTempFile("marathon",".json").with {
+            deleteOnExit()
+
+            write """{
+  "id": "testcontainer",
+  "mem": 10,
+  "instances": 1,
+  "cmd": "while [ true ] ; do echo 'Hello Marathon' ; sleep 5 ; done"
+}"""
+            marathonFilePath = absolutePath
+        }
+        return marathonFilePath
+    }
 }

--- a/src/test/groovy/cz/alenkacz/gradle/marathon/deploy/PrintTaskTest.groovy
+++ b/src/test/groovy/cz/alenkacz/gradle/marathon/deploy/PrintTaskTest.groovy
@@ -24,6 +24,7 @@ class PrintTaskTest extends Specification {
             marathon {
                 dockerImageName = "imagename"
                 pathToJsonFile = "${MarathonJsonMother.validDockerMarathonJsonPath()}"
+                url = "${MarathonMother.getMarathonUrl()}"
             }
         """
 


### PR DESCRIPTION
This enables you not to specify actual number of cpus, it gets computed based on `mem` and `cpuProfile` you entered and current Mesos CPU/RAM ratio.